### PR TITLE
Fix: Resend logic

### DIFF
--- a/contact-form-whatsapp-validation.php
+++ b/contact-form-whatsapp-validation.php
@@ -386,13 +386,74 @@ class ContactFormWhatsAppValidation {
      * AJAX handler for resending OTP
      */
     public function ajax_resend_otp() {
-        check_ajax_referer('cfwv_nonce', 'nonce');
-        
-        $session_token = sanitize_text_field($_POST['session_token']);
-        
-        $result = $this->otp_handler->resend_otp($session_token);
-        
-        wp_send_json($result);
+        try {
+            // Verify nonce
+            if (!isset($_POST['nonce']) || !check_ajax_referer('cfwv_nonce', 'nonce', false)) {
+                wp_send_json(array(
+                    'success' => false,
+                    'message' => 'Security check failed. Please refresh the page and try again.'
+                ));
+                return;
+            }
+            
+            // Get and validate session token
+            if (!isset($_POST['session_token']) || empty($_POST['session_token'])) {
+                error_log('CFWV: AJAX Resend OTP - Missing session_token in POST data');
+                wp_send_json(array(
+                    'success' => false,
+                    'message' => 'Session token is required.'
+                ));
+                return;
+            }
+            
+            $session_token = sanitize_text_field($_POST['session_token']);
+            
+            // Check if otp_handler is initialized
+            if (!isset($this->otp_handler) || !$this->otp_handler) {
+                error_log('CFWV: AJAX Resend OTP - OTP handler not initialized');
+                wp_send_json(array(
+                    'success' => false,
+                    'message' => 'System error. Please try again later.'
+                ));
+                return;
+            }
+            
+            // Resend OTP
+            $result = $this->otp_handler->resend_otp($session_token);
+            
+            // Ensure result is in correct format
+            if (!is_array($result)) {
+                error_log('CFWV: AJAX Resend OTP - Invalid result format: ' . print_r($result, true));
+                wp_send_json(array(
+                    'success' => false,
+                    'message' => 'An unexpected error occurred. Please try again.'
+                ));
+                return;
+            }
+            
+            // Ensure success key exists
+            if (!isset($result['success'])) {
+                $result['success'] = false;
+            }
+            
+            // Send response
+            wp_send_json($result);
+            
+        } catch (Exception $e) {
+            error_log('CFWV: AJAX Resend OTP - Exception: ' . $e->getMessage());
+            error_log('CFWV: AJAX Resend OTP - Stack trace: ' . $e->getTraceAsString());
+            wp_send_json(array(
+                'success' => false,
+                'message' => 'An error occurred while resending the code. Please try again.'
+            ));
+        } catch (Error $e) {
+            error_log('CFWV: AJAX Resend OTP - Fatal Error: ' . $e->getMessage());
+            error_log('CFWV: AJAX Resend OTP - Stack trace: ' . $e->getTraceAsString());
+            wp_send_json(array(
+                'success' => false,
+                'message' => 'A fatal error occurred. Please contact support.'
+            ));
+        }
     }
     
     /**
@@ -420,9 +481,12 @@ class ContactFormWhatsAppValidation {
         ?>
         <div class="cfwv-otp-verification-container">
             <div class="cfwv-otp-header">
-                <h2 style="margin-bottom: 10px; font-size: 24px; font-weight: 600; color: #333;">Verify Your Phone Number</h2>
+                <h2 style="margin-bottom: 10px; font-size: 24px; font-weight: 600; color: #333;">Verifying WhatsApp</h2>
                 <p style="margin-bottom: 20px; font-size: 16px; color: #666;"><?php echo $session->phone_number; ?></p>
-                <p style="margin-bottom: 20px; font-size: 14px; color: #666;">Please wait 2-3 minutes to receive the code</p>
+                <div style="display: flex; flex-direction: column; gap: 0px;">
+                    <p style="font-size: 14px; color: #666; padding: 0; margin: 0;">Please wait 2 minutes to receive the code</p>
+                    <p style="font-size: 14px; color: #666; padding: 0; margin: 0;">We need to make sure our sales team can reach you</p>
+                </div>
             </div>
             
             <form id="cfwv-otp-form" class="cfwv-otp-form">

--- a/includes/class-database.php
+++ b/includes/class-database.php
@@ -555,6 +555,29 @@ class CFWV_Database {
     }
     
     /**
+     * Update OTP session with new OTP code
+     */
+    public function update_otp_session($session_id, $otp_code, $reset_attempts = true) {
+        $otp_sessions_table = $this->wpdb->prefix . 'cfwv_otp_sessions';
+        
+        $data = array(
+            'otp_code' => $otp_code
+        );
+        
+        if ($reset_attempts) {
+            $data['attempts'] = 0;
+        }
+        
+        return $this->wpdb->update(
+            $otp_sessions_table,
+            $data,
+            array('id' => $session_id),
+            $reset_attempts ? array('%s', '%d') : array('%s'),
+            array('%d')
+        );
+    }
+    
+    /**
      * Verify OTP code
      */
     public function verify_otp($session_token, $otp_code) {

--- a/includes/class-otp-handler.php
+++ b/includes/class-otp-handler.php
@@ -209,49 +209,75 @@ class CFWV_OTPHandler {
      * Resend OTP
      */
     public function resend_otp($session_token) {
-        $session = $this->get_otp_session($session_token);
-        
-        if (!$session) {
+        try {
+            // Validate session token
+            if (empty($session_token)) {
+                error_log('CFWV: Resend OTP - Empty session token');
+                return array(
+                    'success' => false,
+                    'message' => 'Invalid session token'
+                );
+            }
+            
+            // Get session
+            $session = $this->get_otp_session($session_token);
+            
+            if (!$session) {
+                error_log('CFWV: Resend OTP - Session not found for token: ' . $session_token);
+                return array(
+                    'success' => false,
+                    'message' => 'Invalid or expired session'
+                );
+            }
+            
+            error_log('CFWV: Resend OTP - Session found, ID: ' . $session->id . ', Phone: ' . $session->phone_number);
+            
+            // Generate new OTP
+            $new_otp = $this->generate_otp();
+            error_log('CFWV: Resend OTP - Generated new OTP: ' . $new_otp);
+            
+            // Update session with new OTP
+            $update_result = $this->database->update_otp_session($session->id, $new_otp, true);
+            
+            if ($update_result === false) {
+                error_log('CFWV: Resend OTP - Database update failed');
+                return array(
+                    'success' => false,
+                    'message' => 'Failed to update session. Please try again.'
+                );
+            }
+            
+            error_log('CFWV: Resend OTP - Session updated successfully');
+            
+            // Update submission with new OTP code and sent timestamp
+            if (!empty($session->submission_id)) {
+                $this->database->update_submission_otp($session->submission_id, $new_otp);
+                error_log('CFWV: Resend OTP - Submission OTP updated');
+            }
+            
+            // Send new OTP
+            $send_result = $this->send_otp_via_whatsapp($session->phone_number, $new_otp, 'Contact Form');
+            error_log('CFWV: Resend OTP - Send result: ' . print_r($send_result, true));
+            
+            // Always try to store sender WhatsApp number, even if send failed
+            if (!empty($send_result['sender']) && !empty($session->submission_id)) {
+                $this->database->update_submission_sender($session->submission_id, $send_result['sender']);
+            }
+            
+
+            return array(
+                'success' => true,
+                'message' => 'OTP resent successfully'
+            );
+            
+        } catch (Exception $e) {
+            error_log('CFWV: Resend OTP - Exception: ' . $e->getMessage());
+            error_log('CFWV: Resend OTP - Stack trace: ' . $e->getTraceAsString());
             return array(
                 'success' => false,
-                'message' => 'Invalid or expired session'
+                'message' => 'An error occurred while resending the code. Please try again.'
             );
         }
-        
-        // Generate new OTP
-        $new_otp = $this->generate_otp();
-        
-        // Update session with new OTP
-        $otp_sessions_table = $this->database->wpdb->prefix . 'cfwv_otp_sessions';
-        $this->database->wpdb->update(
-            $otp_sessions_table,
-            array(
-                'otp_code' => $new_otp,
-                'otp_sent_at' => current_time('mysql'),
-                'attempts' => 0
-            ),
-            array('id' => $session->id)
-        );
-        
-        // Send new OTP
-        $send_result = $this->send_otp_via_whatsapp($session->phone_number, $new_otp, 'Contact Form');
-        
-        // Always try to store sender WhatsApp number, even if send failed
-        if (!empty($send_result['sender']) && !empty($session->submission_id)) {
-            $this->database->update_submission_sender($session->submission_id, $send_result['sender']);
-        }
-        
-        if (!$send_result['success']) {
-            return array(
-                'success' => false,
-                'message' => $send_result['message']
-            );
-        }
-        
-        return array(
-            'success' => true,
-            'message' => 'OTP resent successfully'
-        );
     }
     
     /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens OTP resend by adding nonce/session validation, robust error handling, a DB session update method, and minor verification UI text changes.
> 
> - **Backend**:
>   - **AJAX**: Strengthen `ajax_resend_otp` in `contact-form-whatsapp-validation.php` with explicit nonce check, session token validation, handler existence check, result-shape enforcement, and try/catch with logging.
>   - **OTP Handler**: Refactor `CFWV_OTPHandler::resend_otp` to use new DB method, add extensive logging, input/session validation, and exception handling; always update submission sender when available.
>   - **Database**: Add `CFWV_Database::update_otp_session($session_id, $otp_code, $reset_attempts)` to persist new OTP and optionally reset attempts.
> - **Frontend/UI**:
>   - OTP verification header and helper text updated in `shortcode_otp_verification` (copy changes only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c17ea0b881743c3ab023fd4fc8304ad92910772. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->